### PR TITLE
Ping the database after connection to ensure we can successfully query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@NHSDigital/ee-utils",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "license": "MIT",
   "type": "module",
   "author": "jacobgill1 <jacob.gill1@nhs.net>",
@@ -26,6 +26,8 @@
     "@aws-sdk/client-s3": "^3.515.0",
     "@aws-sdk/client-ssm": "^3.519.0",
     "@aws-sdk/middleware-retry": "^3.374.0",
+    "@octokit/core": "^6.1.2",
+    "@octokit/plugin-throttling": "^9.2.1",
     "@octokit/rest": "^20.0.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.1.0",

--- a/src/__tests__/mongo.test.ts
+++ b/src/__tests__/mongo.test.ts
@@ -1,52 +1,90 @@
 import mongoose from "mongoose";
-import { LambdaLogger } from "../logger";
-import { connectToDatabaseViaEnvVar } from "../mongodb/mongo";
+import { connectToDatabaseViaEnvVar, ILog } from "../mongodb/mongo";
 
-jest.mock("mongoose");
+import { Writable } from 'stream';
+import winston from 'winston';
+
+const fakeLogger = (): [ILog, string[]] => {
+  let output: any[] = [];
+  const stream = new Writable()
+  stream._write = (chunk, encoding, next) => {
+      output.push(chunk.toString());
+      next()
+  }
+
+  const streamTransport = new winston.transports.Stream({ stream })
+  const logger = winston.createLogger({ transports: [streamTransport]})
+  return [logger, output];
+};
+
+const mongooseIsConnected = () => {
+  return mongoose.connection.readyState === 1;
+};
+
+const ensureMongooseIsConnected = async () => {
+  if (!mongooseIsConnected()) {
+    await mongoose.connect(process.env.MONGODB_URI!);
+  }
+}
+
+const ensureMongooseIsDisconnected = async () => {
+  if (mongooseIsConnected()) {
+    await mongoose.disconnect();
+  }
+}
 
 describe("connectToDatabaseViaEnvVar", () => {
+  let originalMongoDBUri:(string|undefined)= "";
+
+  beforeAll(async () => {
+    originalMongoDBUri = process.env.MONGODB_URI;
+  });
+
+  beforeEach(async () => {
+    process.env.MONGODB_URI = originalMongoDBUri;
+    await ensureMongooseIsDisconnected();
+  });
+
+  afterEach(async () => {
+    process.env.MONGODB_URI = originalMongoDBUri;
+    await ensureMongooseIsConnected();
+  });
+
   it("should log an error when the environment variable is not set", async () => {
-    const loggerSpy = jest.spyOn(LambdaLogger.prototype, "error");
+    const [logger, logOutput] = fakeLogger();
 
     delete process.env.MONGODB_URI;
 
     try {
-      await connectToDatabaseViaEnvVar();
+      await connectToDatabaseViaEnvVar({ssl: false, tlsCAFile: "", serverSelectionTimeoutMS: 0}, logger);
     } catch (error: any) {
       expect(error.message).toEqual("MONGODB_URI environment variable not set");
     }
 
-    expect(loggerSpy).toHaveBeenCalledWith("ENGEXPUTILS006", {
-      error: "MONGODB_URI environment variable not set",
-    });
+    const errorLog = logOutput.find((log) => log.includes("ENGEXPUTILS006"))!;
+    expect(JSON.parse(errorLog)["error"]).toEqual("MONGODB_URI environment variable not set");
   });
+
   it("should connect to the mongoose database when the URI is set", async () => {
-    const loggerSpy = jest.spyOn(LambdaLogger.prototype, "info");
+    const [logger, logOutput] = fakeLogger();
 
-    process.env.MONGODB_URI = "mongodb://";
+    await connectToDatabaseViaEnvVar({ssl: false, tlsCAFile: "", serverSelectionTimeoutMS: 100}, logger);
 
-    await connectToDatabaseViaEnvVar();
-
-    expect(loggerSpy).toHaveBeenCalledWith("ENGEXPUTILS007", {
-      database: "mongodb://",
-    });
+    const errorLog = logOutput.find((log) => log.includes("ENGEXPUTILS007"))!;
+    expect(JSON.parse(errorLog)["database"]).toEqual(process.env.MONGODB_URI);
   });
+
   it("should log an error if the connection to the database fails", async () => {
-    const loggerSpy = jest.spyOn(LambdaLogger.prototype, "error");
+    const [logger, logOutput] = fakeLogger();
 
-    (mongoose.connect as jest.MockedFunction<any>).mockRejectedValue(
-      "Connection Failed"
-    );
-    process.env.MONGODB_URI = "mongodb://";
-
+    process.env.MONGODB_URI = "mongodb://127.0.0.1:6666";
     try {
-      await connectToDatabaseViaEnvVar();
-    } catch (error) {
-      expect(error).toEqual("Connection Failed");
+      await connectToDatabaseViaEnvVar({ssl: false, tlsCAFile: "", serverSelectionTimeoutMS: 100}, logger);
+    } catch (error: any) {
+      expect(error["message"]).toEqual("connect ECONNREFUSED 127.0.0.1:6666");
     }
 
-    expect(loggerSpy).toHaveBeenCalledWith("ENGEXPUTILS008", {
-      error: "Connection Failed",
-    });
+    const errorLog = logOutput.find((log) => log.includes("ENGEXPUTILS008"))!;
+    expect(JSON.parse(errorLog)["error"]).toEqual("MongooseServerSelectionError: connect ECONNREFUSED 127.0.0.1:6666");
   });
 });

--- a/src/logReferences.ts
+++ b/src/logReferences.ts
@@ -9,5 +9,6 @@ export const logReferences: Record<string, string> = {
   ENGEXPUTILS008: "Connection Failed",
   ENGEXPUTILS009: "Octokit Parameters Fetched",
   ENGEXPUTILS010: "Octokit App Fetched",
-  ENGEXPUTILS011: "Retrieving all repositories in org"
+  ENGEXPUTILS011: "Retrieving all repositories in org",
+  ENGEXPUTILS012: "Checking database connection",
 };


### PR DESCRIPTION
The purpose of this patch is to check that we can successfully query the database after the connection is made, in an attempt to rule out any networking problems that might be getting in the way of us inserting data.

Because this involves delving into the guts of the `mongoose` global to get at the database connection, this means that the connection tests could no longer rely on running against a mock object, but instead need to run against an actual database.  That has resulted in some moderately intrusive changes to the mongo tests and the addition of some configuration for the `connectToDatabaseViaEnvVar` function; in particular it now accepts a timeout parameter (so that the test which fails to connect can do so quickly) and a logger (so that the tests are no longer coupled to the precise combination of logger calls that get made.